### PR TITLE
Extend API with PHPCS version

### DIFF
--- a/process/phpcs_test.go
+++ b/process/phpcs_test.go
@@ -188,6 +188,7 @@ func TestPhpcs_Run(t *testing.T) {
 		Out             chan Processor
 		TempFolder      string
 		StorageProvider storage.Provider
+		Versions        map[string]string
 	}
 
 	validFields := fields{
@@ -195,6 +196,10 @@ func TestPhpcs_Run(t *testing.T) {
 		Out:             make(chan Processor),
 		StorageProvider: &mockStorage{},
 		TempFolder:      "./testdata/tmp",
+		Versions: map[string]string{
+			"phpcompatibility": "0.0.1-phpcompat",
+			"wordpress":        "0.0.1-wp",
+		},
 	}
 
 	tests := []struct {
@@ -211,6 +216,7 @@ func TestPhpcs_Run(t *testing.T) {
 				Out:             make(chan Processor),
 				StorageProvider: &mockStorage{},
 				TempFolder:      "./testdata/tmp",
+				Versions:        validFields.Versions,
 			},
 			nil,
 			true,
@@ -223,6 +229,7 @@ func TestPhpcs_Run(t *testing.T) {
 				In:              make(chan Processor),
 				StorageProvider: &mockStorage{},
 				TempFolder:      "./testdata/tmp",
+				Versions:        validFields.Versions,
 			},
 			nil,
 			true,
@@ -235,6 +242,7 @@ func TestPhpcs_Run(t *testing.T) {
 				In:              make(chan Processor),
 				Out:             make(chan Processor),
 				StorageProvider: &mockStorage{},
+				Versions:        validFields.Versions,
 			},
 			nil,
 			true,
@@ -247,6 +255,7 @@ func TestPhpcs_Run(t *testing.T) {
 				In:         make(chan Processor),
 				Out:        make(chan Processor),
 				TempFolder: "./testdata/tmp",
+				Versions:   validFields.Versions,
 			},
 			nil,
 			true,
@@ -254,8 +263,85 @@ func TestPhpcs_Run(t *testing.T) {
 			true,
 		},
 		{
+			"No Versions",
+			fields{
+				In:              make(chan Processor),
+				Out:             make(chan Processor),
+				StorageProvider: &mockStorage{},
+				TempFolder:      "./testdata/tmp",
+			},
+			nil,
+			true,
+			false,
+			true,
+		},
+		{
+			"No Version - Phpcompatibility",
+			fields{
+				In:              make(chan Processor),
+				Out:             make(chan Processor),
+				StorageProvider: &mockStorage{},
+				TempFolder:      "./testdata/tmp",
+				Versions:        map[string]string{},
+			},
+			[]Processor{
+				&Info{
+					Process: Process{
+						Message: message.Message{
+							Title:  "Valid Phpcompat",
+							Slug:   "test",
+							Audits: auditsPhpCompatibility,
+						},
+						Result: &Result{
+							"checksum": "39c7d71a68565ddd7b6a0fd68d94924d0db449a99541439b3ab8a477c5f1fc4e",
+						},
+						FilesPath: "./testdata/info/plugin",
+					},
+				},
+			},
+			true,
+			true,
+			false,
+		},
+		{
+			"No Version - WordPress",
+			fields{
+				In:              make(chan Processor),
+				Out:             make(chan Processor),
+				StorageProvider: &mockStorage{},
+				TempFolder:      "./testdata/tmp",
+				Versions:        map[string]string{},
+			},
+			[]Processor{
+				&Info{
+					Process: Process{
+						Message: message.Message{
+							Title:  "Valid Test",
+							Slug:   "test",
+							Audits: auditsWordPress,
+						},
+						Result: &Result{
+							"checksum": "39c7d71a68565ddd7b6a0fd68d94924d0db449a99541439b3ab8a477c5f1fc4e",
+						},
+						FilesPath: "./testdata/info/plugin",
+					},
+				},
+			},
+			true,
+			true,
+			false,
+		},
+		{
 			"Valid Item - WordPress",
-			validFields,
+			fields{
+				In:              make(chan Processor),
+				Out:             make(chan Processor),
+				StorageProvider: &mockStorage{},
+				TempFolder:      "./testdata/tmp",
+				Versions: map[string]string{
+					"wordpress": "0.0.1-wp",
+				},
+			},
 			[]Processor{
 				&Info{
 					Process: Process{
@@ -282,6 +368,7 @@ func TestPhpcs_Run(t *testing.T) {
 				Out:             make(chan Processor),
 				StorageProvider: &mockStorage{},
 				TempFolder:      "./testdata/tmp",
+				Versions:        validFields.Versions,
 			},
 			[]Processor{
 				&Info{
@@ -306,6 +393,7 @@ func TestPhpcs_Run(t *testing.T) {
 				Out:             make(chan Processor),
 				StorageProvider: &mockStorage{},
 				TempFolder:      "./testdata/tmp",
+				Versions:        validFields.Versions,
 			},
 			[]Processor{
 				&Info{
@@ -330,6 +418,7 @@ func TestPhpcs_Run(t *testing.T) {
 				Out:             make(chan Processor),
 				StorageProvider: &mockStorage{},
 				TempFolder:      "./testdata/tmp",
+				Versions:        validFields.Versions,
 			},
 			[]Processor{
 				&Info{
@@ -352,7 +441,15 @@ func TestPhpcs_Run(t *testing.T) {
 		},
 		{
 			"Valid Item - Phpcompatibility",
-			validFields,
+			fields{
+				In:              make(chan Processor),
+				Out:             make(chan Processor),
+				StorageProvider: &mockStorage{},
+				TempFolder:      "./testdata/tmp",
+				Versions: map[string]string{
+					"phpcompatibility": "0.0.1-phpcompat",
+				},
+			},
 			[]Processor{
 				&Info{
 					Process: Process{
@@ -470,6 +567,7 @@ func TestPhpcs_Run(t *testing.T) {
 				Out:             make(chan Processor),
 				StorageProvider: &mockStorage{},
 				TempFolder:      "closeContext",
+				Versions:        validFields.Versions,
 			},
 			[]Processor{},
 			true,
@@ -570,6 +668,7 @@ func TestPhpcs_Run(t *testing.T) {
 				In:              make(chan Processor),
 				Out:             make(chan Processor),
 				StorageProvider: &mockStorage{},
+				Versions:        validFields.Versions,
 			},
 			nil,
 			false,
@@ -629,6 +728,7 @@ func TestPhpcs_Run(t *testing.T) {
 				Out:             tt.fields.Out,
 				TempFolder:      tt.fields.TempFolder,
 				StorageProvider: tt.fields.StorageProvider,
+				Versions:        tt.fields.Versions,
 			}
 
 			cs.SetContext(ctx)

--- a/tide/item.go
+++ b/tide/item.go
@@ -66,6 +66,7 @@ type AuditResult struct {
 	IncompatibleVersions []string               `json:"incompatible_versions,omitempty"`
 	Error                string                 `json:"error,omitempty"`
 	Extra                map[string]interface{} `json:"extra,omitempty"`
+	Version              string                 `json:"version,omitempty"`
 }
 
 // PhpcsResults contains the results from a phpcs audit.


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
This PR allows a version to be specified for the PHPCS process being run. By passing in a map of versions, the PHPCS process will determine the version of the PHPCS and add it to the audit result.

The `PHPcs` structure now has a `Versions` field which holds a mapping of PHPCS versions. The version of the PHPCS is retrieved from this mapping and then added to the `AuditResult` structure.

An error will be thrown if `Versions` or the version of PHPCS is undefined.

----

The `AuditResult` stucture now has a `Version` field to accommodate the version of PHPCS or Lighthouse being run.

### Verification Process

Manual testing was done to ensure the API returns a PHPCS version. Also, tests were written to ensure versions were passed to the PHPCS process and that the version for a PHPCS exists.

### Applicable Issues

<!-- Enter any applicable Issues here -->
Fixes wptide/wptide#144.